### PR TITLE
updated git:// to https:// to account for github changes

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-	{nitro_cache, {git, "git://github.com/nitrogen/nitro_cache", {branch, master}}},
-	{erlias, {git, "git://github.com/choptastic/erlias", {branch, master}}}
+	{nitro_cache, {git, "https://github.com/nitrogen/nitro_cache", {branch, master}}},
+	{erlias, {git, "https://github.com/choptastic/erlias", {branch, master}}}
 ]}.


### PR DESCRIPTION
Hi -- Got caught by the legacy git:// while building up an old project.  Thought I'd send along a quick patch.  Thanks!